### PR TITLE
feat(CodeArtifact): add option to provide aws credentials directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ codeArtifactRepository {
         profile.set("customer1")
         // reuses properties of the default extension if not explicitly specified
     }
+    additional("customer2") {
+        // if a profile is not available you can also provide the credentials directly
+        accessKeyId = System.getenv("CUSTOMER2_AWS_ACCESS_KEY_ID")
+        secretAccessKey = System.getenv("AWS_SECRET_ACCESS_KEY")
+        // reuses properties of the default extension if not explicitly specified
+    }
 }
 
 dependencyResolutionManagement {

--- a/src/main/kotlin/com/liftric/code/artifact/repository/CodeArtifact.kt
+++ b/src/main/kotlin/com/liftric/code/artifact/repository/CodeArtifact.kt
@@ -1,7 +1,9 @@
 package com.liftric.code.artifact.repository
 
 import org.gradle.api.provider.Property
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.codeartifact.CodeartifactClient
 import software.amazon.awssdk.services.codeartifact.model.GetAuthorizationTokenResponse
@@ -15,15 +17,28 @@ abstract class CodeArtifact {
     abstract val region: Property<Region>
     abstract val profile: Property<String>
     abstract val tokenExpiresIn: Property<Long>
+    abstract val accessKeyId: Property<String>
+    abstract val secretAccessKey: Property<String>
 
     private val stsClient by lazy {
         StsClient.builder().apply {
             region.orNull?.let {
                 region(it)
             }
-            profile.orNull?.let {
+            if (accessKeyId.orNull != null && secretAccessKey.orNull != null) {
                 credentialsProvider {
-                    ProfileCredentialsProvider.create(profile.get()).resolveCredentials()
+                    StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(
+                            accessKeyId.get(),
+                            secretAccessKey.get(),
+                        )
+                    ).resolveCredentials()
+                }
+            } else {
+                profile.orNull?.let {
+                    credentialsProvider {
+                        ProfileCredentialsProvider.create(profile.get()).resolveCredentials()
+                    }
                 }
             }
         }.build()
@@ -34,9 +49,20 @@ abstract class CodeArtifact {
             region.orNull?.let {
                 region(it)
             }
-            profile.orNull?.let {
+            if (accessKeyId.orNull != null && secretAccessKey.orNull != null) {
                 credentialsProvider {
-                    ProfileCredentialsProvider.create(profile.get()).resolveCredentials()
+                    StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(
+                            accessKeyId.get(),
+                            secretAccessKey.get(),
+                        )
+                    ).resolveCredentials()
+                }
+            } else {
+                profile.orNull?.let {
+                    credentialsProvider {
+                        ProfileCredentialsProvider.create(profile.get()).resolveCredentials()
+                    }
                 }
             }
         }.build()

--- a/src/main/kotlin/com/liftric/code/artifact/repository/CodeArtifactRepositoryExtension.kt
+++ b/src/main/kotlin/com/liftric/code/artifact/repository/CodeArtifactRepositoryExtension.kt
@@ -13,6 +13,8 @@ abstract class CodeArtifactRepositoryExtension(private val extensionContainer: E
             block.invoke(this)
             region.convention(this@CodeArtifactRepositoryExtension.region)
             profile.convention(this@CodeArtifactRepositoryExtension.profile)
+            accessKeyId.convention(this@CodeArtifactRepositoryExtension.accessKeyId)
+            secretAccessKey.convention(this@CodeArtifactRepositoryExtension.secretAccessKey)
             tokenExpiresIn.convention(this@CodeArtifactRepositoryExtension.tokenExpiresIn)
         }
     }


### PR DESCRIPTION
TLDR: This PR adds the option to declare AWS credentials directly instead of pulling them from a profile.

Background: We have a project where we need two sets of AWS credentials for our e2e tests (one is for us and one is for our customer). Locally we have two profiles for them, but in our gitlab CI we inject these via environment variables. When I tried to add this plugin to our project I encountered the problem that it only accepts profiles for selecting the correct credentials. This works fine locally but in our CI the plugin simply takes the default credentials from the environment variables which are the wrong ones. As our CI has no profiles we cannot select the correct credentials with this plugin. My solution is to add the option to directly declare the `accessKeyId` and `secretAccessKey` in the configuration (e.g. via environment variables).